### PR TITLE
chore(ci): use RUST_LOG=trace only for coverage 

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Install sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - run: |
-            # to get the symbolizer for debug symbol resolution
-            sudo apt install llvm
-            # to fix buggy leak analyzer:
-            # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
-            # ensure there's a profile.dev section
-            if ! grep -qE '^[ \t]*[profile.dev]' Cargo.toml; then
-                echo >> Cargo.toml
-                echo '[profile.dev]' >> Cargo.toml
-            fi
-            # remove pre-existing opt-levels in profile.dev
-            sed -i '/^\s*\[profile.dev\]/,/^\s*\[/ {/^\s*opt-level/d}' Cargo.toml
-            # now set opt-level to 1
-            sed -i '/^\s*\[profile.dev\]/a opt-level = 1' Cargo.toml
-            cat Cargo.toml
+          # to get the symbolizer for debug symbol resolution
+          sudo apt install llvm
+          # to fix buggy leak analyzer:
+          # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
+          # ensure there's a profile.dev section
+          if ! grep -qE '^[ \t]*[profile.dev]' Cargo.toml; then
+              echo >> Cargo.toml
+              echo '[profile.dev]' >> Cargo.toml
+          fi
+          # remove pre-existing opt-levels in profile.dev
+          sed -i '/^\s*\[profile.dev\]/,/^\s*\[/ {/^\s*opt-level/d}' Cargo.toml
+          # now set opt-level to 1
+          sed -i '/^\s*\[profile.dev\]/a opt-level = 1' Cargo.toml
+          cat Cargo.toml
         name: Enable debug symbols
       - name: cargo test -Zsanitizer=address
         # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
-  # Enable logging otherwise the logging lines will count as not covered in the test coverage
-  RUST_LOG: trace
 jobs:
   required:
     runs-on: ubuntu-latest
@@ -59,6 +57,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     name: ubuntu / stable / coverage
+    env:
+      # Enable logging otherwise the logging lines will count as not covered in the test coverage
+      RUST_LOG: trace
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This will prevent the test logs to became too verbose.